### PR TITLE
Update caliopen-dev for use of new caliopen.web and caliopen.api

### DIFF
--- a/start
+++ b/start
@@ -31,7 +31,8 @@ echo "Have to wait for cassandra to be up"
 sleep 15
 
 echo "Start server"
-pserve --reload "${CALIOPEN_DIR}/web/development.ini.sample"
+
+DEBUG=caliopen.web:* NODE_ENV=development node ${WEB_DIR}/bin/start
 
 echo "stop containers"
 $COMPOSE_CMD stop

--- a/start
+++ b/start
@@ -7,6 +7,7 @@ DEV_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${DEV_DIR}/common.sh"
 
 WEB_DIR="${CALIOPEN_DIR}/web"
+API_DIR="${CALIOPEN_DIR}/api"
 VENV_DIR="${CALIOPEN_DIR}/venv"
 
 echo "Activate virtualenv"
@@ -30,9 +31,12 @@ $COMPOSE_CMD up -d redis cassandra elasticsearch rabbitmq
 echo "Have to wait for cassandra to be up"
 sleep 15
 
+echo "Start HTTP APIs"
+pserve --reload ${API_DIR}/development.ini.sample &
+
 echo "Start server"
 
-DEBUG=caliopen.web:* NODE_ENV=development node ${WEB_DIR}/bin/start
+DEBUG=caliopen.web:* NODE_ENV=development nodemon ${WEB_DIR}/bin/start --watch ${WEB_DIR}/app
 
 echo "stop containers"
 $COMPOSE_CMD stop


### PR DESCRIPTION
Do not merge until the new [caliopen.web](https://github.com/ziir/caliopen.web) has been forked.

- [ ] Update bin/install
- [ ] Update bin/start