### PR TITLE
Update storage engine

### DIFF
--- a/update
+++ b/update
@@ -45,3 +45,7 @@ done
 (cd ${DEV_DIR} && ${COMPOSE_CMD} build api web web-client-ng)
 
 cd ${CURRDIR}
+
+# Update storage engines models
+CALIOPEN_BASE_DIR=/usr/share/caliopen/base
+${COMPOSE_CMD} run cli caliopen -f ${CALIOPEN_BASE_DIR}/caliopen.yaml.template setup

--- a/update
+++ b/update
@@ -42,7 +42,7 @@ do
 done
 
 
-(cd ${DEV_DIR} && ${COMPOSE_CMD} build api web web-client-ng)
+(cd ${DEV_DIR} && ${COMPOSE_CMD} build api web web-client-ng cli)
 
 cd ${CURRDIR}
 


### PR DESCRIPTION
The more simpler strategy I found for now to update cassandra keyspace (add new model, new colum) when updating development platform.

Containers supposed to run, may we must ensure they are running and start them otherwise ?