### PR TITLE
Force https usage on nginx

### DIFF
--- a/integration/nginx/sites-available/web
+++ b/integration/nginx/sites-available/web
@@ -4,7 +4,7 @@ upstream nodeapp {
 }
 
 server {
-    # listen        443 ssl;
+    listen        443 ssl;
     listen              [::]:443 ssl;
     server_name         poc.caliopen.org;
 
@@ -27,6 +27,7 @@ server {
 
 server {
     listen [::]:80;
+    listen 80;
     server_name poc.caliopen.org;
     rewrite     ^(.*)   https://$server_name$1 permanent;
 }

--- a/integration/nginx/sites-available/web
+++ b/integration/nginx/sites-available/web
@@ -1,14 +1,20 @@
 upstream nodeapp {
-  #server [::1]:4000;
   server 0.0.0.0:4000;
   keepalive 8;
 }
 
 server {
-  server_name poc2.caliopen.org;
-  listen 80;
+    # listen        443 ssl;
+    listen              [::]:443 ssl;
+    server_name         poc.caliopen.org;
 
-  location / {
+    ssl_certificate     /etc/nginx/certs/caliopen.crt;
+    ssl_certificate_key /etc/nginx/certs/caliopen.key;
+    ssl_prefer_server_ciphers On;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;
+
+    location / {
     proxy_http_version 1.1;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -17,4 +23,10 @@ server {
     proxy_pass http://nodeapp;
     proxy_redirect off;
   }
+}
+
+server {
+    listen [::]:80;
+    server_name poc.caliopen.org;
+    rewrite     ^(.*)   https://$server_name$1 permanent;
 }


### PR DESCRIPTION
integration will deploy nginx configuration for https usage, redirect from http if needed.

Certificates need to be deployed before (but a private key has no place in a git repository)